### PR TITLE
Standardize Python comment separators

### DIFF
--- a/backtest/backtest_signals.py
+++ b/backtest/backtest_signals.py
@@ -25,7 +25,9 @@ import pandas as pd
 TD_FMT = "%Y-%m-%d"
 DEFAULT_CAPITAL = 1_000_000  # JPY
 
-# ── DB helpers ───────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
 
 def read_prices(conn: sqlite3.Connection) -> pd.DataFrame:
     q = (
@@ -49,14 +51,18 @@ def read_signals(conn: sqlite3.Connection, start: str | None, end: str | None) -
     df = pd.read_sql(q, conn, parse_dates=["DisclosedAt"])
     return df
 
-# ── Trading‑days utility ────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Trading-days utility
+# ---------------------------------------------------------------------------
 
 def add_n_trading_days(s: pd.Series, n: int, calendar: pd.DatetimeIndex) -> pd.Series:
     idx = calendar.searchsorted(s) + n
     idx[idx >= len(calendar)] = len(calendar) - 1
     return calendar[idx]
 
-# ── Backtest core ───────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Backtest core
+# ---------------------------------------------------------------------------
 
 def run_backtest(prices: pd.DataFrame, signals: pd.DataFrame, *,
                  hold: int, offset: int, capital: int) -> pd.DataFrame:
@@ -107,7 +113,9 @@ def summarize(trades: pd.DataFrame) -> pd.DataFrame:
     })
     return summary
 
-# ── Excel output ────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Excel output
+# ---------------------------------------------------------------------------
 
 def to_excel(trades: pd.DataFrame, summary: pd.DataFrame, path: str):
     with pd.ExcelWriter(path, engine="xlsxwriter") as writer:
@@ -134,7 +142,9 @@ def to_excel(trades: pd.DataFrame, summary: pd.DataFrame, path: str):
         chart.set_y_axis({"num_format": "#,##0"})
         sheet.insert_chart("L2", chart)
 
-# ── CLI ─────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
 
 def parse_args(argv=None):
     p = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/fetch/daily_quotes.py
+++ b/fetch/daily_quotes.py
@@ -44,7 +44,9 @@ LOG_FMT = "%(asctime)s [%(levelname)s] %(message)s"
 logging.basicConfig(format=LOG_FMT, level=logging.INFO)
 logger = logging.getLogger("daily_quotes")
 DB_PATH ="../db/stock.db"
-# ------------------------------------------------------------------ helpers --
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
 
 def _load_token() -> str:
     with open("idtoken.json", "r", encoding="utf-8") as f:
@@ -62,7 +64,9 @@ def _daterange(s: dt.date, e: dt.date) -> List[dt.date]:
         d += dt.timedelta(days=1)
     return out
 
-# -------------------------- API with pagination -----------------------------
+# ---------------------------------------------------------------------------
+# API with pagination
+# ---------------------------------------------------------------------------
 
 def _call(session: Session, params: dict, token: str, retries: int = 3) -> dict:
     headers = {"Authorization": f"Bearer {token}"}
@@ -103,7 +107,9 @@ def _by_date(sess: Session, tok: str, d: dt.date) -> pd.DataFrame:
 def _by_code(sess: Session, tok: str, code: str) -> pd.DataFrame:
     return _fetch_all(sess, {"code": code}, tok)
 
-# --------------------------- dataframe utils -------------------------------
+# ---------------------------------------------------------------------------
+# dataframe utils
+# ---------------------------------------------------------------------------
 
 def _norm(df: pd.DataFrame) -> pd.DataFrame:
     rename = {"Code": "code", "Date": "date", "Open": "open", "High": "high", "Low": "low",
@@ -125,7 +131,9 @@ def _norm(df: pd.DataFrame) -> pd.DataFrame:
              "adj_close", "adj_volume"]
     return df[[c for c in order if c in df.columns]]
 
-# ------------------------------- SQLite ------------------------------------
+# ---------------------------------------------------------------------------
+# SQLite
+# ---------------------------------------------------------------------------
 
 def _upsert(conn: sqlite3.Connection, df: pd.DataFrame) -> None:
     if df.empty:
@@ -140,7 +148,9 @@ def _upsert(conn: sqlite3.Connection, df: pd.DataFrame) -> None:
         DROP TABLE _tmp_q;
     """)
 
-# ------------------------------- main --------------------------------------
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
 
 def fetch_and_load(start: Optional[str], end: Optional[str]) -> None:
     tok = _load_token()
@@ -167,7 +177,9 @@ def fetch_and_load(start: Optional[str], end: Optional[str]) -> None:
                 _upsert(conn, _norm(_by_code(sess, tok, c)))
     logger.info("Done")
 
-# ------------------------------- CLI ---------------------------------------
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
 
 def _cli() -> None:
     ap = argparse.ArgumentParser(description="Download J‑Quants daily quotes → SQLite")

--- a/screening/screen_statements.py
+++ b/screening/screen_statements.py
@@ -23,9 +23,9 @@ from typing import Final
 
 import pandas as pd
 
-# ────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
 # Configuration
-# ----------------------------------------------------------------
+# ---------------------------------------------------------------------------
 @dataclass(frozen=True)
 class Config:
     db_path: Path = Path("../db/stock.db")
@@ -40,9 +40,9 @@ BOOL_COLS: Final = [
     "ChangesInAccountingEstimates",
 ]
 
-# ────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
 # Helpers
-# ----------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 def _cast_bool(series: pd.Series) -> pd.Series:
     """"true"/"false"/"1"/"0"/NaN/空文字 → bool へ正規化"""
@@ -54,9 +54,9 @@ def _cast_bool(series: pd.Series) -> pd.Series:
         .astype(bool)
     )
 
-# ────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
 # Data Access
-# ----------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 def fetch_statements(conn: sqlite3.Connection, cfg: Config) -> pd.DataFrame:
     """Load recent statements rows from DB and return as DataFrame."""
@@ -97,9 +97,9 @@ def fetch_statements(conn: sqlite3.Connection, cfg: Config) -> pd.DataFrame:
     df.sort_values(["LocalCode", "DisclosedAt"], inplace=True)
     return df
 
-# ────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
 # Feature Engineering
-# ----------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 def compute_features(df: pd.DataFrame, cfg: Config) -> pd.DataFrame:
     """Add QoQ / YoY / quality metrics per LocalCode."""
@@ -145,9 +145,9 @@ def compute_features(df: pd.DataFrame, cfg: Config) -> pd.DataFrame:
 
     return df.groupby("LocalCode", group_keys=False).apply(_add)
 
-# ────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
 # Screening
-# ----------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 def screen_signals(df: pd.DataFrame, cfg: Config) -> pd.DataFrame:
     """Apply sequential filters and log stage counts."""
@@ -177,9 +177,9 @@ def screen_signals(df: pd.DataFrame, cfg: Config) -> pd.DataFrame:
     logging.debug("Stage counts: %s", stage)
     return df.loc[m].copy()
 
-# ────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
 # Persistence
-# ----------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 def save_signals(sig_df: pd.DataFrame, conn: sqlite3.Connection) -> int:
     if sig_df.empty:
@@ -212,9 +212,9 @@ def save_signals(sig_df: pd.DataFrame, conn: sqlite3.Connection) -> int:
     conn.commit()
     return len(sig)
 
-# ────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
 # CLI / Main
-# ----------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Screen statements for fundamental signals.")


### PR DESCRIPTION
## Summary
- use consistent `# ---------------------------------------------------------------------------` lines
- apply to backtest helper sections
- apply to data fetching scripts
- apply to screening script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684432ac627c83268405dbd242eac7cb