### PR TITLE
Use relative DB_PATH

### DIFF
--- a/backtest/backtest_signals.py
+++ b/backtest/backtest_signals.py
@@ -24,6 +24,7 @@ import pandas as pd
 
 TD_FMT = "%Y-%m-%d"
 DEFAULT_CAPITAL = 1_000_000  # JPY
+DB_PATH = (Path(__file__).resolve().parents[1] / "db/stock.db").as_posix()
 
 # ---------------------------------------------------------------------------
 # DB helpers
@@ -148,7 +149,7 @@ def to_excel(trades: pd.DataFrame, summary: pd.DataFrame, path: str):
 
 def parse_args(argv=None):
     p = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    p.add_argument("--db", default="../db/stock.db", help="SQLite DB file")
+    p.add_argument("--db", default=DB_PATH, help="SQLite DB file")
     p.add_argument("--hold", type=int, default=40, help="Holding period (trading days)")
     p.add_argument("--entry-offset", type=int, default=1, help="Entry day offset")
     p.add_argument("--capital", type=int, default=DEFAULT_CAPITAL, help="Capital per trade (JPY)")

--- a/backtest/backtest_swing.py
+++ b/backtest/backtest_swing.py
@@ -32,7 +32,7 @@ import sys
 CAPITAL_DEFAULT = 1_000_000
 HOLD_DAYS_DEFAULT = 60
 STOP_LOSS_PCT_DEFAULT = 0.05
-DB_PATH ="../db/stock.db"
+DB_PATH = (Path(__file__).resolve().parents[1] / "db/stock.db").as_posix()
 
 # ---------------------------------------------------------------------------
 # Back-test core

--- a/fetch/daily_quotes.py
+++ b/fetch/daily_quotes.py
@@ -43,7 +43,7 @@ RATE_SLEEP = 0.35  # ~3 req/sec safety
 LOG_FMT = "%(asctime)s [%(levelname)s] %(message)s"
 logging.basicConfig(format=LOG_FMT, level=logging.INFO)
 logger = logging.getLogger("daily_quotes")
-DB_PATH ="../db/stock.db"
+DB_PATH = (Path(__file__).resolve().parents[1] / "db/stock.db").as_posix()
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------

--- a/fetch/listed_info.py
+++ b/fetch/listed_info.py
@@ -39,7 +39,7 @@ API_ENDPOINT = "https://api.jquants.com/v1/listed/info"
 LOG_FMT = "%(asctime)s [%(levelname)s] %(message)s"
 logging.basicConfig(format=LOG_FMT, level=logging.INFO)
 logger = logging.getLogger("listed_info")
-DB_PATH ="../db/stock.db"
+DB_PATH = (Path(__file__).resolve().parents[1] / "db/stock.db").as_posix()
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/fetch/statements.py
+++ b/fetch/statements.py
@@ -40,7 +40,7 @@ API_ENDPOINT = "https://api.jquants.com/v1/fins/statements"
 LOG_FMT = "%(asctime)s [%(levelname)s] %(message)s"
 logging.basicConfig(format=LOG_FMT, level=logging.INFO)
 logger = logging.getLogger("statements")
-DB_PATH = "../db/stock.db"
+DB_PATH = (Path(__file__).resolve().parents[1] / "db/stock.db").as_posix()
 
 # ---------------------------------------------------------------------------
 # SQLite側の statements テーブルに合わせたカラム一覧

--- a/screening/screen_statements.py
+++ b/screening/screen_statements.py
@@ -28,7 +28,7 @@ import pandas as pd
 # ---------------------------------------------------------------------------
 @dataclass(frozen=True)
 class Config:
-    db_path: Path = Path("../db/stock.db")
+    db_path: Path = Path(__file__).resolve().parents[1] / "db/stock.db"
     lookback_days: int = 365 * 3      # 3 年分ロード
     recent_days: int = 7              # 開示から何日以内を対象にするか
     window_q: int = 4                 # 四半期 MA

--- a/screening/technical_swing_tools.py
+++ b/screening/technical_swing_tools.py
@@ -18,7 +18,8 @@ import sqlite3
 import pandas as pd
 import sys
 from datetime import datetime, timedelta
-DB_PATH ="../db/stock.db"
+from pathlib import Path
+DB_PATH = (Path(__file__).resolve().parents[1] / "db/stock.db").as_posix()
 
 # --- Compute flags ----------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- make DB_PATH derive from module location so scripts work regardless of working directory

## Testing
- `python -m py_compile fetch/daily_quotes.py fetch/listed_info.py fetch/statements.py backtest/backtest_swing.py backtest/backtest_signals.py screening/screen_statements.py screening/technical_swing_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_68454ac09c0c8326a66b00d228a2b364