### PR TITLE
Localize CLI help

### DIFF
--- a/backtest/backtest_statements.py
+++ b/backtest/backtest_statements.py
@@ -215,16 +215,16 @@ def to_excel(trades: pd.DataFrame, summary: pd.DataFrame, path: str):
 
 def parse_args(argv=None):
     p = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    p.add_argument("--db", default=DB_PATH, help="SQLite DB file")
-    p.add_argument("--hold", type=int, default=40, help="Holding period (trading days)")
-    p.add_argument("--entry-offset", type=int, default=1, help="Entry day offset")
+    p.add_argument("--db", default=DB_PATH, help="SQLite DB ファイル")
+    p.add_argument("--hold", type=int, default=40, help="保有期間（日数）")
+    p.add_argument("--entry-offset", type=int, default=1, help="エントリー日のオフセット")
     p.add_argument(
-        "--capital", type=int, default=DEFAULT_CAPITAL, help="Capital per trade (JPY)"
+        "--capital", type=int, default=DEFAULT_CAPITAL, help="1 トレードあたりの資金 (JPY)"
     )
-    p.add_argument("--start", type=str, default=None, help="Start date YYYY-MM-DD")
-    p.add_argument("--end", type=str, default=None, help="End date YYYY-MM-DD")
-    p.add_argument("--xlsx", type=str, default="trades.xlsx", help="Excel output path")
-    p.add_argument("-v", "--verbose", action="store_true")
+    p.add_argument("--start", type=str, default=None, help="開始日 YYYY-MM-DD")
+    p.add_argument("--end", type=str, default=None, help="終了日 YYYY-MM-DD")
+    p.add_argument("--xlsx", type=str, default="trades.xlsx", help="Excel 出力ファイル")
+    p.add_argument("-v", "--verbose", action="store_true", help="詳細ログを表示")
     return p.parse_args(argv)
 
 

--- a/backtest/backtest_technical.py
+++ b/backtest/backtest_technical.py
@@ -181,20 +181,20 @@ if __name__ == "__main__":
     # • コマンドライン引数を解析して各種設定を取得
     # • 指定 DB に接続
     # • run_backtest() を呼び出し結果を Excel へ保存
-    parser = argparse.ArgumentParser(description="Swing-trade back-test tool")
-    parser.add_argument("--db", default=DB_PATH, help="SQLite DB path")
-    parser.add_argument("--as-of", required=True, help="Entry date (YYYYMMDD)")
+    parser = argparse.ArgumentParser(description="スイングトレードのバックテストツール")
+    parser.add_argument("--db", default=DB_PATH, help="SQLite DB のパス")
+    parser.add_argument("--as-of", required=True, help="エントリー日 YYYYMMDD")
     parser.add_argument(
-        "--outfile", default="backtest_results.xlsx", help="Excel output path"
+        "--outfile", default="backtest_results.xlsx", help="Excel 出力ファイル"
     )
     parser.add_argument(
-        "--capital", type=int, default=CAPITAL_DEFAULT, help="Capital per trade"
+        "--capital", type=int, default=CAPITAL_DEFAULT, help="1 トレードあたりの資金 (JPY)"
     )
     parser.add_argument(
-        "--hold-days", type=int, default=HOLD_DAYS_DEFAULT, help="Holding period days"
+        "--hold-days", type=int, default=HOLD_DAYS_DEFAULT, help="保有日数"
     )
     parser.add_argument(
-        "--stop-loss", type=float, default=STOP_LOSS_PCT_DEFAULT, help="Stop-loss pct"
+        "--stop-loss", type=float, default=STOP_LOSS_PCT_DEFAULT, help="損切り率"
     )
     args = parser.parse_args()
     conn = sqlite3.connect(args.db)

--- a/fetch/daily_quotes.py
+++ b/fetch/daily_quotes.py
@@ -252,9 +252,9 @@ def fetch_and_load(start: Optional[str], end: Optional[str]) -> None:
 
 def _cli() -> None:
     """Command‑line entry point."""
-    ap = argparse.ArgumentParser(description="Download J‑Quants daily quotes → SQLite")
-    ap.add_argument("--start", help="YYYYMMDD")
-    ap.add_argument("--end", help="YYYYMMDD")
+    ap = argparse.ArgumentParser(description="J‑Quants の日足データを SQLite に保存")
+    ap.add_argument("--start", help="開始日 YYYYMMDD")
+    ap.add_argument("--end", help="終了日 YYYYMMDD")
     a = ap.parse_args()
     fetch_and_load(a.start, a.end)
 


### PR DESCRIPTION
## Summary
- translate CLI help strings to Japanese in `daily_quotes`, `backtest_technical`, and `backtest_statements`

## Testing
- `python -m py_compile fetch/daily_quotes.py backtest/backtest_technical.py backtest/backtest_statements.py`

------
https://chatgpt.com/codex/tasks/task_e_6846ac5e60908326a4eaa918f75a85a6