### PR TITLE
Fix token loader path

### DIFF
--- a/fetch/daily_quotes.py
+++ b/fetch/daily_quotes.py
@@ -71,7 +71,8 @@ _PRICE_COLS = [
 
 def _load_token() -> str:
     """Read the JWT token stored in ``idtoken.json``."""
-    with open("../idtoken.json", "r", encoding="utf-8") as f:
+    path = Path(__file__).resolve().parents[1] / "idtoken.json"
+    with path.open("r", encoding="utf-8") as f:
         tok = json.load(f).get("idToken")
     if not tok:
         raise RuntimeError("idToken not found in idtoken.json")

--- a/fetch/listed_info.py
+++ b/fetch/listed_info.py
@@ -46,7 +46,8 @@ DB_PATH = (Path(__file__).resolve().parents[1] / "db/stock.db").as_posix()
 
 
 def _load_token() -> str:
-    with open("../idtoken.json", "r", encoding="utf-8") as f:
+    path = Path(__file__).resolve().parents[1] / "idtoken.json"
+    with path.open("r", encoding="utf-8") as f:
         tok = json.load(f).get("idToken")
     if not tok:
         raise RuntimeError("idToken not found in idtoken.json")

--- a/fetch/statements.py
+++ b/fetch/statements.py
@@ -164,7 +164,8 @@ SCHEMA_COLUMNS: List[str] = [
 
 
 def _load_token() -> str:
-    with open("../idtoken.json", "r", encoding="utf-8") as f:
+    path = Path(__file__).resolve().parents[1] / "idtoken.json"
+    with path.open("r", encoding="utf-8") as f:
         tok = json.load(f).get("idToken")
     if not tok:
         raise RuntimeError("idToken not found in idtoken.json")


### PR DESCRIPTION
## Summary
- load id token using an absolute path for all fetch modules

## Testing
- `python -m py_compile fetch/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6846c088d2e0832683d175ffb1fdc1f8