### PR TITLE
Revert async features and add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# swimg
+
+This project fetches and processes J-Quants data.
+
+## Development
+
+Install the development tools and set up `pre-commit` hooks:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+The hooks run `black` and `ruff` on each commit.


### PR DESCRIPTION
## Summary
- revert previous async implementation and tests
- add `.pre-commit-config.yaml` with black and ruff
- document pre-commit setup in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c21c670483268008e0db2a01ea75