### PR TITLE
Handle partial data on errors

### DIFF
--- a/fetch/daily_quotes.py
+++ b/fetch/daily_quotes.py
@@ -207,6 +207,7 @@ def _upsert(conn: sqlite3.Connection, df: pd.DataFrame) -> None:
 
     records = df[cols].itertuples(index=False, name=None)
     conn.executemany(sql, records)
+    conn.commit()
 
 
 # ---------------------------------------------------------------------------

--- a/fetch/listed_info.py
+++ b/fetch/listed_info.py
@@ -124,6 +124,7 @@ def _to_db(df: pd.DataFrame, conn: sqlite3.Connection) -> None:
         DROP TABLE _tmp_listed;
         """
     )
+    conn.commit()
     logger.info("listed_info に %d 行 upsert しました", len(mapped))
 
     # 全行の delete_flag を更新（本日日付以外を 1、本日を 0 に設定）

--- a/fetch/statements.py
+++ b/fetch/statements.py
@@ -295,6 +295,7 @@ def _upsert(conn: sqlite3.Connection, records: List[dict]) -> None:
         DROP TABLE _tmp_statements;
         """
     )
+    conn.commit()
     logger.info("statements テーブルに %d 行 upsert しました", len(df))
 
 


### PR DESCRIPTION
## Summary
- ensure upserts commit immediately for daily quotes
- ensure listed info writes commit before flag updates
- commit statements inserts individually

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e01d99248326a44ad85a9e82e928