### PR TITLE
Add as-of date option for fundamental screening

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pre-commit install
   `--start` と `--end` を併用することで期間を指定できます。
 * `screening/screen_statements.py`
   財務データをスクリーニングし、シグナルを `fundamental_signals` に保存します。
-  `--lookback` 過去参照日数、`--recent` 開示閾値日数を指定できます。
+  `--lookback` 過去参照日数、`--recent` 開示閾値日数、`--as-of` 基準日（省略時は当日）を指定できます。
 * `screening/screen_technical.py`
   `indicators` または `screen` をコマンドとして指定します。  
   `--as-of` で対象日を指定し、`--lookback` は遡る日数です。

--- a/gui.py
+++ b/gui.py
@@ -126,9 +126,14 @@ def build_screen_fund_tab(nb, output):
     ttk.Label(arg, text="開示閾値:").grid(row=0, column=2)
     recent = tk.StringVar(value="7")
     ttk.Entry(arg, textvariable=recent, width=5).grid(row=0, column=3)
+    ttk.Label(arg, text="基準日 (省略可):").grid(row=1, column=0, sticky="e")
+    as_of = tk.StringVar()
+    ttk.Entry(arg, textvariable=as_of, width=12).grid(row=1, column=1)
 
     def _run():
         cmd = f"python screening/screen_statements.py --lookback {lookback.get()} --recent {recent.get()}"
+        if as_of.get():
+            cmd += f" --as-of {as_of.get()}"
         run_command(cmd, output)
 
     ttk.Button(frame, text="実行", command=_run).pack(pady=5)


### PR DESCRIPTION
## Summary
- note default base date is today when `--as-of` isn't provided
- explain this in README and GUI label
- use `field(default_factory=date.today)` for the config dataclass

## Testing
- `black screening/screen_statements.py gui.py`
- `ruff check screening/screen_statements.py gui.py`
- `python -m py_compile screening/screen_statements.py gui.py`
- `pre-commit run --files screening/screen_statements.py gui.py README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e5f112848326ab22d73b593374df