### PR TITLE
Unify logging style

### DIFF
--- a/backtest/backtest_statements.py
+++ b/backtest/backtest_statements.py
@@ -16,8 +16,11 @@ $ python backtest_statements.py \
 """
 
 from __future__ import annotations
-import argparse, logging, math, sqlite3, sys
-from datetime import datetime
+
+import argparse
+import logging
+import sqlite3
+import sys
 from pathlib import Path
 
 import pandas as pd
@@ -25,6 +28,9 @@ import pandas as pd
 TD_FMT = "%Y-%m-%d"
 DEFAULT_CAPITAL = 1_000_000  # JPY
 DB_PATH = (Path(__file__).resolve().parents[1] / "db/stock.db").as_posix()
+
+LOG_FMT = "%(asctime)s [%(levelname)s] %(message)s"
+logger = logging.getLogger("backtest_statements")
 
 # ---------------------------------------------------------------------------
 # DB helpers
@@ -237,18 +243,18 @@ def main():
     args = parse_args()
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
-        format="[%(levelname)s] %(message)s",
+        format=LOG_FMT,
     )
 
     with sqlite3.connect(args.db) as conn:
         prices = read_prices(conn)
         signals = read_signals(conn, args.start, args.end)
 
-    logging.info("signals : %d rows", len(signals))
-    logging.info("prices  : %d rows", len(prices))
+    logger.info("signals : %d rows", len(signals))
+    logger.info("prices  : %d rows", len(prices))
 
     if signals.empty:
-        logging.warning("No signals to back‑test.")
+        logger.warning("No signals to back‑test.")
         sys.exit()
 
     trades = run_backtest(
@@ -256,10 +262,10 @@ def main():
     )
     summary = summarize(trades)
 
-    logging.info("Saving Excel → %s", args.xlsx)
+    logger.info("Saving Excel → %s", args.xlsx)
     to_excel(trades, summary, args.xlsx)
 
-    print(summary.to_string(index=False))
+    logger.info("\n%s", summary.to_string(index=False))
 
 
 if __name__ == "__main__":

--- a/db/db_schema.py
+++ b/db/db_schema.py
@@ -11,8 +11,12 @@ This file intentionally contains **only ASCII characters** to avoid the
 """
 
 import sqlite3
-import sys
+import logging
 from pathlib import Path
+
+LOG_FMT = "%(asctime)s [%(levelname)s] %(message)s"
+logging.basicConfig(format=LOG_FMT, level=logging.INFO)
+logger = logging.getLogger("db_schema")
 
 DB_PATH = "./stock.db"
 
@@ -241,7 +245,7 @@ def init_schema(db_path: Path) -> None:
 
 def main() -> None:  # pragma: no cover
     init_schema(DB_PATH)
-    print("Schema created or verified at", DB_PATH)
+    logger.info("Schema created or verified at %s", DB_PATH)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace scattered `print` calls with logging
- use a common log format in technical/backtest scripts
- add logging to DB schema initializer

## Testing
- `pre-commit run --files backtest/backtest_statements.py backtest/backtest_technical.py db/db_schema.py screening/screen_technical.py` *(fails: pre-commit not installed)*
- `black backtest/backtest_statements.py backtest/backtest_technical.py db/db_schema.py screening/screen_technical.py`
- `ruff check backtest/backtest_statements.py backtest/backtest_technical.py db/db_schema.py screening/screen_technical.py`

------
https://chatgpt.com/codex/tasks/task_e_684e8e88a9b48326a527e3afe72c6f05