### PR TITLE
Add idtoken refresh tool and GUI tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ python db/db_schema.py
   テクニカル指標を用いたスイングトレードのバックテストを行います。
   `--start` と `--end` でエントリー期間を指定し、`--hold-days` 保有日数、
   `--stop-loss` 損切り率、`--capital` 資金、`--outfile` 出力ファイル名を指定します。
+* `update_idtoken.py`
+  メールアドレスとパスワードから refresh token を取得し、
+  `idtoken.json` を更新します。`--mail` と `--password` を指定できます。
 
 ## 利用の流れ
 

--- a/gui.py
+++ b/gui.py
@@ -265,6 +265,29 @@ def build_backtest_tech_tab(nb, output):
     ttk.Button(frame, text="実行", command=_run).pack(pady=5)
 
 
+def build_update_token_tab(nb, output):
+    frame = ttk.Frame(nb)
+    nb.add(frame, text="IDトークン更新")
+    desc = "メールアドレスとパスワードから refresh token を取得し idtoken.json を更新します。"
+    ttk.Label(frame, text=desc, wraplength=400, justify="left").pack(
+        anchor="w", padx=5, pady=5
+    )
+    arg = ttk.Frame(frame)
+    arg.pack(anchor="w", padx=5)
+    mail = tk.StringVar(value="example@example.com")
+    pwd = tk.StringVar(value="password")
+    ttk.Label(arg, text="メールアドレス:").grid(row=0, column=0, sticky="e")
+    ttk.Entry(arg, textvariable=mail, width=25).grid(row=0, column=1)
+    ttk.Label(arg, text="パスワード:").grid(row=1, column=0, sticky="e")
+    ttk.Entry(arg, textvariable=pwd, width=25, show="*").grid(row=1, column=1)
+
+    def _run():
+        cmd = f"python update_idtoken.py --mail {mail.get()} --password {pwd.get()}"
+        run_command(cmd, output)
+
+    ttk.Button(frame, text="実行", command=_run).pack(pady=5)
+
+
 def build_output_controls(root, output_widget):
     """Create buttons to manage the output widget."""
     frame = ttk.Frame(root)
@@ -293,6 +316,7 @@ def main():
     build_screen_tech_tab(nb, output)
     build_backtest_stmt_tab(nb, output)
     build_backtest_tech_tab(nb, output)
+    build_update_token_tab(nb, output)
 
     root.mainloop()
 

--- a/update_idtoken.py
+++ b/update_idtoken.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""Update idtoken.json using J-Quants authentication API."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import requests
+
+API_AUTH = "https://api.jquants.com/v1/token/auth_user"
+API_REFRESH = "https://api.jquants.com/v1/token/auth_refresh"
+
+
+def _get_refresh_token(mail: str, password: str) -> str:
+    """Return refreshToken by authenticating with email and password."""
+    resp = requests.post(
+        API_AUTH,
+        json={"mailaddress": mail, "password": password},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    js = resp.json()
+    if "refreshToken" not in js:
+        raise RuntimeError("refreshToken not found in response")
+    return js["refreshToken"]
+
+
+def _get_id_token(refresh_token: str) -> str:
+    """Return idToken using a refresh token."""
+    resp = requests.post(
+        API_REFRESH,
+        json={"refreshToken": refresh_token},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    js = resp.json()
+    if "idToken" not in js:
+        raise RuntimeError("idToken not found in response")
+    return js["idToken"]
+
+
+def update(mail: str, password: str, outfile: str) -> str:
+    """Update idtoken.json and return the token."""
+    ref = _get_refresh_token(mail, password)
+    token = _get_id_token(ref)
+    path = Path(outfile)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump({"idToken": token}, f)
+    return token
+
+
+def _cli() -> None:
+    ap = argparse.ArgumentParser(description="update idtoken.json")
+    ap.add_argument("--mail", default="example@example.com", help="registered email")
+    ap.add_argument("--password", default="password", help="login password")
+    ap.add_argument("--out", default="idtoken.json", help="output file")
+    a = ap.parse_args()
+    update(a.mail, a.password, a.out)
+
+
+if __name__ == "__main__":
+    _cli()


### PR DESCRIPTION
## Summary
- add `update_idtoken.py` for refreshing the JWT token via J-Quants API
- expose the token update through a new GUI tab
- document the new script in README

## Testing
- `black update_idtoken.py gui.py`
- `ruff check update_idtoken.py gui.py`
- `pre-commit run --files update_idtoken.py gui.py README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e965a0a448326b5d7e574d07b74fe