### PR TITLE
Add simple scheduler for periodic tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,16 @@ python db/db_schema.py
 
 操作をまとめた簡易 GUI (`gui.py`) も用意しています。
 
+## 定期実行
+
+`scheduler.py` を起動しておくと株価や決算情報の取得を自動化できます。
+利用には `schedule` ライブラリが必要です。
+
+```bash
+pip install schedule
+python scheduler.py
+```
+
+デフォルトでは毎日 20:00 に日足株価、20:30 に決算情報を取得し、
+月曜 6:00 に上場銘柄情報を更新します。
+

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,46 @@
+import logging
+import subprocess
+import time
+
+import schedule
+
+logging.basicConfig(
+    format="%(asctime)s [%(levelname)s] %(message)s", level=logging.INFO
+)
+logger = logging.getLogger("scheduler")
+
+
+def _run(cmd: str) -> None:
+    """Run *cmd* and log if it fails."""
+    logger.info("Run: %s", cmd)
+    proc = subprocess.run(cmd, shell=True)
+    if proc.returncode:
+        logger.error("Command failed: %s", cmd)
+
+
+def fetch_quotes() -> None:
+    _run("python fetch/daily_quotes.py")
+
+
+def fetch_statements() -> None:
+    _run("python fetch/statements.py 2")
+
+
+def update_listed_info() -> None:
+    _run("python fetch/listed_info.py")
+
+
+schedule.every().day.at("20:00").do(fetch_quotes)
+schedule.every().day.at("20:30").do(fetch_statements)
+schedule.every().monday.at("06:00").do(update_listed_info)
+
+
+def main() -> None:
+    logger.info("scheduler start")
+    while True:
+        schedule.run_pending()
+        time.sleep(30)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide `scheduler.py` to run data fetch jobs on a schedule
- document periodic execution in README

## Testing
- `python -m black scheduler.py`
- `python -m ruff check scheduler.py`
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea5ab3e3c8326b15e13b93cfa0900