### PR TITLE
Log API messages

### DIFF
--- a/fetch/daily_quotes.py
+++ b/fetch/daily_quotes.py
@@ -100,8 +100,11 @@ def _call(session: Session, params: dict, token: str, retries: int = 3) -> dict:
     for i in range(retries):
         r: Response = session.get(API_URL, headers=headers, params=params, timeout=60)
         if r.status_code < 400:
+            js = r.json()
+            if "message" in js:
+                logger.info("API message: %s", js["message"])
             time.sleep(RATE_SLEEP)
-            return r.json()
+            return js
         wait = 2**i
         logger.warning("HTTP %s → %ss 後に再試行", r.status_code, wait)
         time.sleep(wait)

--- a/fetch/listed_info.py
+++ b/fetch/listed_info.py
@@ -61,7 +61,10 @@ def _fetch_listed_info(idtoken: str) -> pd.DataFrame:
     if resp.status_code != 200:
         raise RuntimeError(f"API error {resp.status_code}: {resp.text}")
 
-    data = resp.json().get("info", [])
+    js = resp.json()
+    if "message" in js:
+        logger.info("API message: %s", js["message"])
+    data = js.get("info", [])
     if not data:
         raise ValueError("/listed/info response contained no 'info' key")
 

--- a/fetch/statements.py
+++ b/fetch/statements.py
@@ -186,6 +186,8 @@ def _fetch_statements_by_code(session: Session, idtoken: str, code: str) -> List
             logger.warning("コード %s のAPIエラー: %s", code, resp.text)
             resp.raise_for_status()
         data = resp.json()
+        if "message" in data:
+            logger.info("API message: %s", data["message"])
         stmts = data.get("statements", [])
         if not stmts:
             break
@@ -213,6 +215,8 @@ def _fetch_statements_by_date(
             logger.warning("日付 %s のAPIエラー: %s", date_str, resp.text)
             resp.raise_for_status()
         data = resp.json()
+        if "message" in data:
+            logger.info("API message: %s", data["message"])
         stmts = data.get("statements", [])
         if not stmts:
             break


### PR DESCRIPTION
## Summary
- log `message` field from API responses in fetch scripts

## Testing
- `python -m py_compile fetch/daily_quotes.py fetch/statements.py fetch/listed_info.py`
- ⚠️ `pre-commit` could not run because the environment lacks internet access to install it

------
https://chatgpt.com/codex/tasks/task_e_684ea72698ec83269a741f8df75665b8