### PR TITLE
Skip technical indicator run when prices missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ python db/db_schema.py
   財務データをスクリーニングし、シグナルを `fundamental_signals` に保存します。
   `--lookback` 過去参照日数、`--recent` 開示閾値日数、`--as-of` 基準日（省略時は当日）を指定できます。
 * `screening/screen_technical.py`
-  `indicators` または `screen` をコマンドとして指定します。  
+  `indicators` または `screen` をコマンドとして指定します。
   `--as-of` で対象日を指定し、`--lookback` は遡る日数です。
+  当日の `prices` データが存在しない場合は処理をスキップします。
 * `backtest/backtest_statements.py`
   財務シグナルを用いたバックテストを実行します。  
   `--hold` 保有日数、`--entry-offset` エントリー日のオフセット、`--capital` 資金、  

--- a/screening/screen_technical.py
+++ b/screening/screen_technical.py
@@ -124,6 +124,12 @@ def compute_indicators(df):
 def run_indicators(conn, as_of=None):
     if not as_of:
         as_of = datetime.today().strftime("%Y-%m-%d")
+    cnt = conn.execute("SELECT COUNT(*) FROM prices WHERE date=?", (as_of,)).fetchone()[
+        0
+    ]
+    if cnt == 0:
+        logger.info("%s の価格データがないためスキップ", as_of)
+        return
     codes = [
         row[0] for row in conn.execute("SELECT DISTINCT code FROM prices").fetchall()
     ]


### PR DESCRIPTION
## Summary
- skip indicator calculation if there is no price data for the day
- document the skip behaviour in README

## Testing
- `black screening/screen_technical.py`
- `ruff check screening/screen_technical.py`
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec42df2d4832688b1c9fc8043a479