### PR TITLE
Fix TypeError in backtest_technical

### DIFF
--- a/backtest/backtest_technical.py
+++ b/backtest/backtest_technical.py
@@ -23,6 +23,9 @@ Optional parameters:
   --hold-days   保有日数 (default=60)
   --stop-loss   損切り閾値 (fraction, default=0.05)
 """
+
+from __future__ import annotations
+
 import argparse
 import sqlite3
 import pandas as pd


### PR DESCRIPTION
## Summary
- add `from __future__ import annotations` to `backtest_technical.py`

## Testing
- `python backtest/backtest_technical.py --start 2024-10-31 --hold-days 60 --stop-loss 0.05 --capital 1000000 --outfile backtest_results.xlsx --end 2024-10-31` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pre-commit run --files backtest/backtest_technical.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed408af4483269e26d243a467991e