### PR TITLE
Fix matplotlib layout for backtest results

### DIFF
--- a/backtest/backtest_statements.py
+++ b/backtest/backtest_statements.py
@@ -200,7 +200,7 @@ def show_results_window(trades: pd.DataFrame, summary: pd.DataFrame) -> None:
         show_results(trades, summary)
         return
 
-    fig, axes = plt.subplots(3, 1, figsize=(8, 8))
+    fig, axes = plt.subplots(3, 1, figsize=(8, 8), constrained_layout=True)
 
     # Summary table
     axes[0].axis("off")
@@ -230,7 +230,6 @@ def show_results_window(trades: pd.DataFrame, summary: pd.DataFrame) -> None:
     axes[2].set_xlabel("Trade #")
     axes[2].set_ylabel("Profit (JPY)")
 
-    plt.tight_layout()
     plt.show()
 
 

--- a/backtest/backtest_technical.py
+++ b/backtest/backtest_technical.py
@@ -224,7 +224,7 @@ def show_results_window(trades: pd.DataFrame, summary: pd.DataFrame) -> None:
         show_results(trades, summary)
         return
 
-    fig, axes = plt.subplots(3, 1, figsize=(8, 8))
+    fig, axes = plt.subplots(3, 1, figsize=(8, 8), constrained_layout=True)
 
     # Summary table
     axes[0].axis("off")
@@ -254,7 +254,6 @@ def show_results_window(trades: pd.DataFrame, summary: pd.DataFrame) -> None:
     axes[2].set_xlabel("Trade #")
     axes[2].set_ylabel("Profit (JPY)")
 
-    plt.tight_layout()
     plt.show()
 
 


### PR DESCRIPTION
## Summary
- use constrained layout for backtest result figures to avoid overlapping

## Testing
- `pip install pre-commit` *(fails: no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_685136c321a4832681af6b1b2951bd07