### PR TITLE
Add DB summary utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ python db/db_schema.py
 * `update_idtoken.py`
   J‑Quants にログインして `idtoken.json` を更新します。
   `--mail` と `--password` を省略すると `account.json` が参照されます。
+* `db/db_summary.py`
+  データベースの各テーブル件数と日付範囲を表示します。引数はありません。
+  GUI の「DBサマリー」タブからも確認できます。
 
 ## 利用の流れ
 

--- a/db/db_summary.py
+++ b/db/db_summary.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+"""Show a quick summary of the SQLite database."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path(__file__).resolve().parent / "stock.db"
+
+TABLES = {
+    "prices": "date",
+    "listed_info": "date",
+    "statements": "DisclosedDate",
+    "fundamental_signals": "created_at",
+    "technical_indicators": "signal_date",
+}
+
+
+def main() -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        for table, date_col in TABLES.items():
+            cur = conn.execute(
+                f"SELECT COUNT(*), MIN({date_col}), MAX({date_col}) FROM {table}"
+            )
+            count, min_d, max_d = cur.fetchone()
+            print(f"{table:20s}: rows={count:7d}  range=[{min_d} .. {max_d}]")
+
+
+if __name__ == "__main__":
+    main()

--- a/gui.py
+++ b/gui.py
@@ -344,6 +344,21 @@ def build_update_token_tab(nb, output):
     ttk.Button(frame, text="実行", command=_run).pack(pady=5)
 
 
+def build_db_summary_tab(nb, output):
+    frame = ttk.Frame(nb)
+    nb.add(frame, text="DBサマリー")
+    desc = "データベースの件数と日付範囲を表示します。"
+    ttk.Label(frame, text=desc, wraplength=400, justify="left").pack(
+        anchor="w", padx=5, pady=5
+    )
+
+    def _run():
+        cmd = "python db/db_summary.py"
+        run_command(cmd, output)
+
+    ttk.Button(frame, text="実行", command=_run).pack(pady=5)
+
+
 def build_output_controls(root, output_widget):
     """Create buttons to manage the output widget."""
     frame = ttk.Frame(root)
@@ -373,6 +388,7 @@ def main():
     build_backtest_stmt_tab(nb, output)
     build_backtest_tech_tab(nb, output)
     build_update_token_tab(nb, output)
+    build_db_summary_tab(nb, output)
 
     root.mainloop()
 


### PR DESCRIPTION
## Summary
- add a DB summary tab in the tkinter GUI so users can inspect the database
- mention the GUI tab in the README

## Testing
- `black gui.py db/db_summary.py`
- `ruff check gui.py db/db_summary.py`
- ❌ `pre-commit run --files gui.py README.md db/db_summary.py` *(failed: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685139327d788326b52785c42051ad04