### PR TITLE
Fix ASCII chart sign formatting

### DIFF
--- a/backtest/analyze_backtest_json.py
+++ b/backtest/analyze_backtest_json.py
@@ -92,7 +92,7 @@ def _ascii_bar_chart(values: List[float], width: int = 40) -> str:
     for i, v in enumerate(values, 1):
         bar = "#" * int(abs(v) / max_v * width)
         sign = "" if v >= 0 else "-"
-        lines.append(f"{i:>3} {sign}{bar} ({v:.0f})")
+        lines.append(f"{i:>3} {sign}{bar} ({v:+.0f})")
     return "\n".join(lines)
 
 

--- a/backtest/backtest_statements.py
+++ b/backtest/backtest_statements.py
@@ -198,7 +198,7 @@ def _ascii_bar_chart(values: list[float], width: int = 40) -> str:
     for i, v in enumerate(values, 1):
         bar = "#" * int(abs(v) / max_v * width)
         sign = "" if v >= 0 else "-"
-        lines.append(f"{i:>3} {sign}{bar} ({v:.0f})")
+        lines.append(f"{i:>3} {sign}{bar} ({v:+.0f})")
     return "\n".join(lines)
 
 

--- a/backtest/backtest_technical.py
+++ b/backtest/backtest_technical.py
@@ -220,7 +220,7 @@ def _ascii_bar_chart(values: list[float], width: int = 40) -> str:
     for i, v in enumerate(values, 1):
         bar = "#" * int(abs(v) / max_v * width)
         sign = "" if v >= 0 else "-"
-        lines.append(f"{i:>3} {sign}{bar} ({v:.0f})")
+        lines.append(f"{i:>3} {sign}{bar} ({v:+.0f})")
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary
- show `+` sign for positive profits in ASCII charts

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f7af95108326948f0a6d621f3245