### PR TITLE
Add grid lines to Trades table output

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,31 @@ python db/db_schema.py
   バックテスト結果として保存した JSON ファイルを読み込み、損益や
   勝率などの指標を集計するツールです。複数ファイルを指定して
   まとめて分析することもできます。GUI の「JSON分析」タブからも
-  実行できます。
+  実行できます。以下は簡単な実行例です。
+
+  ```bash
+  $ python backtest/analyze_backtest_json.py sample.json --show-trades
+
+  === Summary ===
+        trades: 2
+  total_profit: 500 JPY
+      win_rate: 50.00%
+   avg_ret_pct: 0.02%
+        sharpe: 0.43
+
+  === Trades ===
+  +------+------------+---------+
+  | code | profit_jpy | ret_pct |
+  +------+------------+---------+
+  | 1234 |       1000 |    0.05 |
+  +------+------------+---------+
+  | 5678 |       -500 |   -0.02 |
+  +------+------------+---------+
+
+  === Profit per Trade ===
+    1 ######################################## (1000)
+    2 -#################### (-500)
+  ```
 * `update_idtoken.py`
   J‑Quants にログインして `idtoken.json` を更新します。
   `--mail` と `--password` を省略すると `account.json` が参照されます。

--- a/backtest/analyze_backtest_json.py
+++ b/backtest/analyze_backtest_json.py
@@ -96,6 +96,28 @@ def _ascii_bar_chart(values: List[float], width: int = 40) -> str:
     return "\n".join(lines)
 
 
+
+def _ascii_table(df: pd.DataFrame) -> str:
+    """Return a simple ASCII table with borders between cells."""
+    cols = list(df.columns)
+    widths = [max(len(str(v)) for v in [c] + df[c].astype(str).tolist()) for c in cols]
+
+    def border() -> str:
+        return "+" + "+".join("-" * (w + 2) for w in widths) + "+"
+
+    lines = [border()]
+    header = "|" + "|".join(f" {c.ljust(w)} " for c, w in zip(cols, widths)) + "|"
+    lines.append(header)
+    lines.append(border())
+    for _, row in df.iterrows():
+        line = "|" + "|".join(
+            f" {str(row[c]).rjust(w)} " for c, w in zip(cols, widths)
+        ) + "|"
+        lines.append(line)
+        lines.append(border())
+    return "\n".join(lines)
+
+
 def main(argv: List[str] | None = None) -> None:
     ap = argparse.ArgumentParser(description="Backtest JSON analyzer")
     ap.add_argument("files", nargs="+", help="JSON files to analyze")
@@ -119,7 +141,7 @@ def main(argv: List[str] | None = None) -> None:
 
     if args.show_trades:
         print("\n=== Trades ===")
-        print(trades.to_string(index=False))
+        print(_ascii_table(trades.reset_index(drop=True)))
         profit_col = _find_col(trades, PROFIT_COLUMNS)
         print("\n=== Profit per Trade ===")
         chart = _ascii_bar_chart(trades[profit_col].tolist())


### PR DESCRIPTION
## Summary
- improve the trades view by drawing an ASCII grid table
- update README example showing framed Trades section

## Testing
- `pre-commit run --files README.md backtest/analyze_backtest_json.py` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6853f7c2021c8326bae1d3afaf890fe8