### PR TITLE
Add default date filtering for signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ python db/db_schema.py
 * `db/db_summary.py`
   データベースの各テーブル件数と日付範囲を表示します。引数はありません。
   GUI の「DBサマリー」タブからも確認できます。
+* `db/list_signals.py`
+  `fundamental_signals` または `technical_indicators` テーブルから
+  スクリーニング結果を表示します。引数 `fund`/`tech` で種別を選択し、
+  `--start` `--end` で期間を指定できます。開始日と終了日をどちらも
+  指定しない場合は当日の日付が自動的に使われます。テクニカルの場合は
+  バックテストと同じ条件（`signals_count>=3` など）が自動で適用されます。
 
 ## 利用の流れ
 

--- a/db/list_signals.py
+++ b/db/list_signals.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+"""List screening signals stored in the SQLite database."""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from pathlib import Path
+import datetime as dt
+
+import pandas as pd
+
+DB_PATH = Path(__file__).resolve().parent / "stock.db"
+TABLES = {
+    "fund": ("fundamental_signals", "DisclosedAt"),
+    "tech": ("technical_indicators", "signal_date"),
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Show recent screening signals from the DB"
+    )
+    parser.add_argument("kind", choices=TABLES.keys(), help="fund or tech")
+    parser.add_argument("--db", default=DB_PATH, help="SQLite DB path")
+    parser.add_argument("--start", help="開始日 YYYY-MM-DD")
+    parser.add_argument("--end", help="終了日 YYYY-MM-DD")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="開始/終了日の指定がない場合に表示する件数",
+    )
+    args = parser.parse_args()
+
+    # ── default date range ───────────────────────────────────────────────
+    if not args.start and not args.end:
+        today = dt.date.today().isoformat()
+        args.start = today
+        args.end = today
+
+    table, date_col = TABLES[args.kind]
+
+    filters: list[str] = []
+    params: list[str | int] = []
+
+    if args.kind == "tech":
+        filters += [
+            "signals_count>=3",
+            "signals_first=1",
+            "signals_overheating=0",
+        ]
+
+    if args.start:
+        filters.append(f"{date_col} >= ?")
+        params.append(args.start)
+    if args.end:
+        filters.append(f"{date_col} <= ?")
+        params.append(args.end)
+
+    with sqlite3.connect(args.db) as conn:
+        if filters:
+            where = " WHERE " + " AND ".join(filters)
+            sql = f"SELECT * FROM {table}{where} ORDER BY {date_col}"
+            df = pd.read_sql(sql, conn, params=params)
+        else:
+            sql = f"SELECT * FROM {table} ORDER BY {date_col} DESC LIMIT ?"
+            df = pd.read_sql(sql, conn, params=(args.limit,))
+
+    if df.empty:
+        print("(no rows)")
+    else:
+        print(df.to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/gui.py
+++ b/gui.py
@@ -456,11 +456,55 @@ def build_analyze_json_tab(nb, output):
 
     btn_frame = ttk.Frame(frame)
     btn_frame.pack(anchor="e", padx=5, pady=5)
-    ttk.Button(btn_frame, text="更新", command=refresh).pack(
-        side="left", padx=(0, 5)
-    )
+    ttk.Button(btn_frame, text="更新", command=refresh).pack(side="left", padx=(0, 5))
     ttk.Button(btn_frame, text="実行", command=_run).pack(side="left")
     refresh()
+
+
+def build_signals_tab(nb, output):
+    """Display screening signals stored in the DB."""
+
+    frame = ttk.Frame(nb)
+    nb.add(frame, text="シグナル確認")
+
+    desc = (
+        "DB に保存されたシグナルを表示します。開始日と終了日を指定しない"
+        "場合は当日分を抽出します。"
+    )
+    ttk.Label(frame, text=desc, wraplength=400, justify="left").pack(
+        anchor="w", padx=5, pady=5
+    )
+
+    arg = ttk.Frame(frame)
+    arg.pack(anchor="w", padx=5)
+
+    ttk.Label(arg, text="種類 (fund/tech):").grid(row=0, column=0)
+    kind_var = tk.StringVar(value="fund")
+    ttk.Entry(arg, textvariable=kind_var, width=8).grid(row=0, column=1)
+
+    ttk.Label(arg, text="開始日:").grid(row=1, column=0)
+    start_var = tk.StringVar()
+    ttk.Entry(arg, textvariable=start_var, width=12).grid(row=1, column=1)
+
+    ttk.Label(arg, text="終了日:").grid(row=2, column=0)
+    end_var = tk.StringVar()
+    ttk.Entry(arg, textvariable=end_var, width=12).grid(row=2, column=1)
+
+    ttk.Label(arg, text="表示件数:").grid(row=3, column=0)
+    limit_var = tk.StringVar(value="20")
+    ttk.Entry(arg, textvariable=limit_var, width=6).grid(row=3, column=1)
+
+    def _run():
+        cmd = (
+            f"python db/list_signals.py {kind_var.get()} " f"--limit {limit_var.get()}"
+        )
+        if start_var.get():
+            cmd += f" --start {start_var.get()}"
+        if end_var.get():
+            cmd += f" --end {end_var.get()}"
+        run_command(cmd, output)
+
+    ttk.Button(frame, text="実行", command=_run).pack(pady=5)
 
 
 def build_results_tab(nb):
@@ -515,9 +559,11 @@ def build_output_controls(root, output_widget):
     ).pack(side="right")
     frame.pack(fill="x", padx=5, pady=(0, 5))
 
+
 ###############################################################################
 # 新規: ML スクリーニングタブ
 ###############################################################################
+
 
 def build_screen_ml_tab(nb: ttk.Notebook, output: tk.Text):
     """Add tab to run ML screening (screen_ml.py)."""
@@ -562,6 +608,7 @@ def build_screen_ml_tab(nb: ttk.Notebook, output: tk.Text):
 
     ttk.Button(frame, text="実行", command=_run).pack(pady=5)
 
+
 def main():
     root = tk.Tk()
     root.title("スイングトレードGUI")
@@ -577,12 +624,13 @@ def main():
     build_statements_tab(nb, output)
     build_screen_fund_tab(nb, output)
     build_screen_tech_tab(nb, output)
-    build_screen_ml_tab(nb, output)   
+    build_screen_ml_tab(nb, output)
     build_backtest_stmt_tab(nb, output)
     build_backtest_tech_tab(nb, output)
     build_update_token_tab(nb, output)
     build_thresholds_tab(nb)
     build_db_summary_tab(nb, output)
+    build_signals_tab(nb, output)
     build_analyze_json_tab(nb, output)
     build_results_tab(nb)
 


### PR DESCRIPTION
## Summary
- default start/end dates to the current day for `db/list_signals.py`
- document the default behaviour in the README
- mention the default in GUI help text

## Testing
- `pre-commit run --files README.md db/list_signals.py gui.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a533f27c8326a32a0106138aa99a