### PR TITLE
Add short signal support

### DIFF
--- a/db/db_schema.py
+++ b/db/db_schema.py
@@ -224,7 +224,12 @@ CREATE TABLE IF NOT EXISTS technical_indicators (
     signal_adx INTEGER,
     signal_bb INTEGER,
     signal_macd INTEGER,
+    signal_ma_short INTEGER,
+    signal_rsi_short INTEGER,
+    signal_bb_short INTEGER,
+    signal_macd_short INTEGER,
     signals_count INTEGER,
+    signals_short_count INTEGER,
     signals_overheating INTEGER,
     signals_first INTEGER,
 


### PR DESCRIPTION
## Summary
- store short signal columns in `technical_indicators`
- compute weighted short signal count in technical screening
- save the short values to the DB and show them in screen output

## Testing
- `ruff check db/db_schema.py screening/screen_technical.py`
- `black db/db_schema.py screening/screen_technical.py`
- `pip install pre-commit` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685537c93c98832696ff2ffad8548bda