### PR TITLE
Add --side filter to JSON analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ python db/db_schema.py
   バックテスト結果として保存した JSON ファイルを読み込み、損益や
   勝率などの指標を集計するツールです。複数ファイルを指定して
   まとめて分析することもできます。GUI の「JSON分析」タブからも
-  実行できます。以下は簡単な実行例です。
+  実行できます。`--side` オプションで `long` または `short` を指定する
+  と、買いもしくは空売りのみを対象に集計できます。以下は簡単な
+  実行例です。
 
   ```bash
   $ python backtest/analyze_backtest_json.py sample.json --show-trades

--- a/backtest/analyze_backtest_json.py
+++ b/backtest/analyze_backtest_json.py
@@ -152,12 +152,24 @@ def main(argv: List[str] | None = None) -> None:
         action="store_true",
         help="print trade table as well",
     )
+    ap.add_argument(
+        "--side",
+        choices=["long", "short", "all"],
+        default="all",
+        help="analyze only long or short trades (default: all)",
+    )
     args = ap.parse_args(argv)
 
     trades = load_trades(args.files)
     if trades.empty:
         print("No trades loaded.")
         return
+
+    if args.side != "all":
+        if "side" in trades.columns:
+            trades = trades[trades["side"] == args.side]
+        else:
+            print("Warning: 'side' column not found. Ignoring --side option.")
 
     summary = summarize(trades)
     summary = format_summary(summary)


### PR DESCRIPTION
## Summary
- filter backtest JSON analysis by side (long/short)
- document new option in README

## Testing
- `python -m py_compile backtest/analyze_backtest_json.py`
- `pre-commit run --files backtest/analyze_backtest_json.py README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855624bc22c8326b128857d1736363f