### PR TITLE
Load thresholds for technical backtests

### DIFF
--- a/backtest/backtest_statements.py
+++ b/backtest/backtest_statements.py
@@ -24,6 +24,10 @@ import sys
 import datetime as dt
 from pathlib import Path
 
+SCREENING_DIR = Path(__file__).resolve().parents[1] / "screening"
+sys.path.append(str(SCREENING_DIR))
+from thresholds import log_thresholds
+
 import pandas as pd
 
 TD_FMT = "%Y-%m-%d"
@@ -279,6 +283,7 @@ def main():
         level=logging.DEBUG if args.verbose else logging.INFO,
         format=LOG_FMT,
     )
+    log_thresholds(logger)
 
     with sqlite3.connect(args.db) as conn:
         prices = read_prices(conn)


### PR DESCRIPTION
## Summary
- import threshold loader in technical backtest scripts
- log current thresholds
- parameterize long-entry query using `SIGNAL_COUNT_MIN`

## Testing
- `python -m py_compile backtest/backtest_statements.py backtest/backtest_technical.py screening/screen_statements.py screening/screen_technical.py`

------
https://chatgpt.com/codex/tasks/task_e_685569074f708326a9b5ccb9c19d8b27