### PR TITLE
Add simple Flask web interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 requests
 schedule
 XlsxWriter
+Flask

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>Swing Web</title>
+</head>
+<body>
+    <h1>Swing Web App</h1>
+    <h2>株価取得</h2>
+    <form action="/run/fetch_quotes" method="post">
+        開始日: <input type="text" name="start">
+        終了日: <input type="text" name="end">
+        <button type="submit">実行</button>
+    </form>
+
+    <h2>上場情報取得</h2>
+    <form action="/run/listed_info" method="post">
+        <button type="submit">実行</button>
+    </form>
+
+    <h2>財務諸表取得</h2>
+    <form action="/run/statements" method="post">
+        モード: <input type="text" name="mode" value="1" size="4">
+        開始日: <input type="text" name="start">
+        終了日: <input type="text" name="end">
+        <button type="submit">実行</button>
+    </form>
+
+    <h2>財務スクリーニング</h2>
+    <form action="/run/screen_fund" method="post">
+        参照期間: <input type="text" name="lookback" value="1095" size="6">
+        開示閾値: <input type="text" name="recent" value="7" size="4">
+        基準日: <input type="text" name="as_of">
+        <button type="submit">実行</button>
+    </form>
+
+    <h2>テクニカルスクリーニング</h2>
+    <form action="/run/screen_tech" method="post">
+        コマンド: <input type="text" name="cmd" value="indicators" size="12">
+        対象日: <input type="text" name="as_of">
+        過去参照日数: <input type="text" name="lookback" value="50" size="6">
+        <button type="submit">実行</button>
+    </form>
+
+    <h2>MLスクリーニング</h2>
+    <form action="/run/screen_ml" method="post">
+        上位件数: <input type="text" name="top" value="30" size="6">
+        学習参照日数: <input type="text" name="lookback" value="1095" size="8">
+        <label><input type="checkbox" name="retrain" value="1">強制再学習</label>
+        <button type="submit">実行</button>
+    </form>
+
+    <h2>ファンダメンタルバックテスト</h2>
+    <form action="/run/backtest_stmt" method="post">
+        保有日数: <input type="text" name="hold" value="40" size="4">
+        オフセット: <input type="text" name="offset" value="1" size="4">
+        資金: <input type="text" name="capital" value="1000000" size="8">
+        開始日: <input type="text" name="start">
+        終了日: <input type="text" name="end">
+        出力ファイル: <input type="text" name="xlsx" value="trades.xlsx" size="12">
+        <button type="submit">実行</button>
+    </form>
+
+    <h2>テクニカルバックテスト</h2>
+    <form action="/run/backtest_tech" method="post">
+        開始日: <input type="text" name="start">
+        終了日: <input type="text" name="end">
+        保有日数: <input type="text" name="hold" value="60" size="4">
+        損切り率: <input type="text" name="stop" value="0.05" size="6">
+        資金: <input type="text" name="capital" value="1000000" size="8">
+        出力ファイル: <input type="text" name="outfile" value="backtest.xlsx" size="15">
+        <button type="submit">実行</button>
+    </form>
+
+    <h2>IDトークン更新</h2>
+    <form action="/run/update_token" method="post">
+        メール: <input type="text" name="mail">
+        パスワード: <input type="password" name="password">
+        <button type="submit">実行</button>
+    </form>
+
+    <h2>DBサマリー</h2>
+    <form action="/run/db_summary" method="post">
+        <button type="submit">実行</button>
+    </form>
+
+    <h2>シグナル確認</h2>
+    <form action="/run/list_signals" method="post">
+        種類:
+        <select name="kind">
+            <option value="fund">ファンダメンタル</option>
+            <option value="tech">テクニカル</option>
+        </select>
+        開始日: <input type="text" name="start">
+        終了日: <input type="text" name="end">
+        表示件数: <input type="text" name="limit" value="20" size="4">
+        <button type="submit">実行</button>
+    </form>
+
+    <h2>JSON分析</h2>
+    <form action="/run/analyze_json" method="post">
+        <select name="files" multiple size="5">
+            {% for f in json_files %}
+            <option value="{{ f }}">{{ f }}</option>
+            {% endfor %}
+        </select>
+        <select name="side">
+            <option value="">両方</option>
+            <option value="long">long</option>
+            <option value="short">short</option>
+        </select>
+        <label><input type="checkbox" name="show_trades" value="1">取引表示</label>
+        <button type="submit">実行</button>
+    </form>
+
+    <h2>閾値設定</h2>
+    <form action="/thresholds" method="post">
+        {% for k, v in thresholds.items() %}
+        {{ k }}: <input type="text" name="{{ k }}" value="{{ v }}" size="6"><br>
+        {% endfor %}
+        <button type="submit">保存</button>
+    </form>
+
+    <h2>結果閲覧</h2>
+    <ul>
+        {% for f in xlsx_files %}
+        <li><a href="{{ f }}">{{ f }}</a></li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/templates/output.html
+++ b/templates/output.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>結果</title>
+</head>
+<body>
+    <h1>実行結果</h1>
+    <pre>{{ command }}</pre>
+    <pre>{{ output }}</pre>
+    <p>終了コード: {{ code }}</p>
+    <p><a href="/">戻る</a></p>
+</body>
+</html>

--- a/web.py
+++ b/web.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import shlex
+from pathlib import Path
+from typing import Tuple
+
+from flask import Flask, render_template, request, redirect, url_for
+
+app = Flask(__name__)
+
+
+def run_command(cmd: str) -> Tuple[str, int]:
+    """Run a shell command and return output and exit code."""
+    proc = subprocess.run(shlex.split(cmd), capture_output=True, text=True)
+    output = proc.stdout + proc.stderr
+    return output, proc.returncode
+
+
+@app.route("/")
+def index():
+    """Render the main page with all forms."""
+    # List Excel and JSON files for results and analysis tabs
+    xlsx_files = sorted(Path(".").glob("*.xlsx"))
+    json_files = sorted(Path(".").glob("*.json"))
+    threshold_path = Path("screening/thresholds.json")
+    thresholds = {}
+    if threshold_path.is_file():
+        with threshold_path.open("r", encoding="utf-8") as f:
+            thresholds = json.load(f)
+    return render_template(
+        "index.html",
+        xlsx_files=xlsx_files,
+        json_files=json_files,
+        thresholds=thresholds,
+    )
+
+
+@app.post("/run/<cmd_name>")
+def run(cmd_name: str):
+    """Handle form submission and execute commands."""
+    form = request.form
+    cmd = ""
+
+    if cmd_name == "fetch_quotes":
+        cmd = "python fetch/daily_quotes.py"
+        if form.get("start"):
+            cmd += f" --start {form['start']}"
+        if form.get("end"):
+            cmd += f" --end {form['end']}"
+    elif cmd_name == "listed_info":
+        cmd = "python fetch/listed_info.py"
+    elif cmd_name == "statements":
+        cmd = f"python fetch/statements.py {form.get('mode', '1')}"
+        if form.get("start"):
+            cmd += f" --start {form['start']}"
+        if form.get("end"):
+            cmd += f" --end {form['end']}"
+    elif cmd_name == "screen_fund":
+        cmd = (
+            f"python screening/screen_statements.py --lookback {form.get('lookback')} "
+            f"--recent {form.get('recent')}"
+        )
+        if form.get("as_of"):
+            cmd += f" --as-of {form['as_of']}"
+    elif cmd_name == "screen_tech":
+        cmd = f"python screening/screen_technical.py {form.get('cmd', 'indicators')}"
+        if form.get("as_of"):
+            cmd += f" --as-of {form['as_of']}"
+        if form.get("lookback"):
+            cmd += f" --lookback {form['lookback']}"
+    elif cmd_name == "screen_ml":
+        cmd = (
+            f"python screening/screen_ml.py screen --top {form.get('top', '30')} "
+            f"--lookback {form.get('lookback', '1095')}"
+        )
+        if form.get("retrain"):
+            cmd += " --retrain"
+    elif cmd_name == "backtest_stmt":
+        out = form.get("xlsx", "trades.xlsx")
+        cmd = (
+            f"python backtest/backtest_statements.py --hold {form.get('hold')} "
+            f"--entry-offset {form.get('offset')} --capital {form.get('capital')} "
+            f"--xlsx {out}"
+        )
+        if form.get("start"):
+            cmd += f" --start {form['start']}"
+        if form.get("end"):
+            cmd += f" --end {form['end']}"
+    elif cmd_name == "backtest_tech":
+        cmd = (
+            f"python backtest/backtest_technical.py --start {form.get('start')} "
+            f"--hold-days {form.get('hold')} --stop-loss {form.get('stop')} "
+            f"--capital {form.get('capital')} --outfile {form.get('outfile')}"
+        )
+        if form.get("end"):
+            cmd += f" --end {form['end']}"
+    elif cmd_name == "update_token":
+        cmd = "python update_idtoken.py"
+        if form.get("mail"):
+            cmd += f" --mail {form['mail']}"
+        if form.get("password"):
+            cmd += f" --password {form['password']}"
+    elif cmd_name == "db_summary":
+        cmd = "python db/db_summary.py"
+    elif cmd_name == "list_signals":
+        cmd = (
+            f"python db/list_signals.py {form.get('kind')} --limit {form.get('limit')}"
+        )
+        if form.get("start"):
+            cmd += f" --start {form['start']}"
+        if form.get("end"):
+            cmd += f" --end {form['end']}"
+    elif cmd_name == "analyze_json":
+        cmd = "python backtest/analyze_backtest_json.py"
+        for fname in request.form.getlist("files"):
+            cmd += f" {fname}"
+        if form.get("side"):
+            cmd += f" --side {form['side']}"
+        if form.get("show_trades"):
+            cmd += " --show-trades"
+    else:
+        return redirect(url_for("index"))
+
+    output, code = run_command(cmd)
+    return render_template("output.html", command=cmd, output=output, code=code)
+
+
+@app.post("/thresholds")
+def save_thresholds():
+    """Update thresholds JSON file."""
+    threshold_path = Path("screening/thresholds.json")
+    data = {k: float(v) for k, v in request.form.items()}
+    with threshold_path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    return redirect(url_for("index"))
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000, debug=True)


### PR DESCRIPTION
## Summary
- add a small Flask-based web app to replicate GUI tasks
- allow editing of screening thresholds
- update requirements with Flask

## Testing
- `black web.py`
- `ruff check web.py`
- `pip install pre-commit` *(fails: proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68556ca4ed00832692d74c52f27f8c06