### PR TITLE
Fix screening import for backtest

### DIFF
--- a/screening/__init__.py
+++ b/screening/__init__.py
@@ -1,0 +1,1 @@
+"""Enable `screening` as a package."""


### PR DESCRIPTION
## Summary
- make `screening` a proper package so other modules can import it

## Testing
- `python -m py_compile backtest/backtest_ml.py screening/screen_ml.py`

------
https://chatgpt.com/codex/tasks/task_e_6855761debcc8326adf4da009f9d38aa