### PR TITLE
Add token update credential form

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -286,10 +286,23 @@ def run(cmd_name: str):
             cmd += f" --end {form['end']}"
     elif cmd_name == "update_token":
         cmd = "python3 -m tools.update_idtoken"
-        if form.get("mail"):
-            cmd += f" --mail {form['mail']}"
-        if form.get("password"):
-            cmd += f" --password {form['password']}"
+        mail = form.get("mail")
+        pwd = form.get("password")
+        if not mail or not pwd:
+            try:
+                from src.utils.config import get_config_manager
+
+                account = get_config_manager().get_account_info()
+                mail = mail or account.get("mailaddress")
+                pwd = pwd or account.get("password")
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning("account.jsonの読み込みに失敗: %s", e)
+                terminal_print(f"account.json load failed: {e}")
+
+        if mail:
+            cmd += f" --mail {mail}"
+        if pwd:
+            cmd += f" --password {pwd}"
     elif cmd_name == "db_summary":
         cmd = "python3 -m data.db.db_summary"
     elif cmd_name == "list_signals":

--- a/web/templates/index_menu.html
+++ b/web/templates/index_menu.html
@@ -592,6 +592,14 @@
             <!-- APIトークン更新 -->
             <div class="form-content" id="form-update-token">
                 <p>J-Quants API のIDトークンを更新します。</p>
+                <div class="form-group">
+                    <label for="token-mail">メールアドレス</label>
+                    <input type="email" id="token-mail" name="mail">
+                </div>
+                <div class="form-group">
+                    <label for="token-pass">パスワード</label>
+                    <input type="password" id="token-pass" name="password">
+                </div>
                 <div class="form-actions">
                     <button class="btn btn-primary" onclick="runCommand('update_token')">トークン更新</button>
                     <button class="btn btn-secondary" onclick="closeForm()">キャンセル</button>


### PR DESCRIPTION
## Summary
- add email/password fields for token update page
- fallback to `account.json` when form is empty

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f80f5ff008326b720ec30f9265d5e